### PR TITLE
Add missing commands with rogue_like_commands option set.

### DIFF
--- a/lib/pref/pref.prf
+++ b/lib/pref/pref.prf
@@ -443,9 +443,13 @@ C:1:X
 A:h
 C:1:^G
 
+# Roguelike keymap: move house
+A:H
+C:1:$
+
+
 # Message colors
 %:message.prf
-
 
 ##### System Specific Subfiles #####
 

--- a/src/store.c
+++ b/src/store.c
@@ -2552,6 +2552,7 @@ static void store_process_command(ui_event ke)
       /*** Various commands ***/
 
 	/* Look at an object */
+    case 'x':
     case 'l':
 	{
 	    store_inspect();


### PR DESCRIPTION
Add missing keymap to lib/pref/pref.prf for "$" to move house as specified in docs. (see related issue I created in your fork)
Add case for 'x' in store_process_commands() in store.c to inspect an item.
