### PR TITLE
fix linux build

### DIFF
--- a/src/main-crb.c
+++ b/src/main-crb.c
@@ -30,7 +30,7 @@
 #include "grafmode.h"
 
 #include <langinfo.h>
-#include <xlocale.h>
+#include <locale.h>
 
 /*
  * Notes:

--- a/src/trap.c
+++ b/src/trap.c
@@ -479,7 +479,7 @@ static int pick_trap(int feat, int trap_level)
 		case TRAP_HEX:
 		case TRAP_PORTAL:
 		case TRAP_MURDER:
-		case TRAP_BRANCH:
+		case TRAP_LIMB:
 			{
 				/* No special restrictions */
 				break;
@@ -1498,7 +1498,7 @@ void hit_trap_aux(int y, int x, int trap)
 		}
 
 		/* falling tree branch */
-	case TRAP_BRANCH:
+	case TRAP_LIMB:
 		{
 			/* determine if the missile hits. */
 			if (check_trap_hit(75 + p_ptr->depth)) {

--- a/src/trap.h
+++ b/src/trap.h
@@ -35,7 +35,7 @@
 #define TRAP_HEX      0x17
 #define TRAP_PORTAL   0x18
 #define TRAP_MURDER   0x19
-#define TRAP_BRANCH   0x1A
+#define TRAP_LIMB     0x1A
 
 /* Specials trap that only effects monsters.  Created only by rogues. -LM- */
 #define MTRAP_HEAD       0x40


### PR DESCRIPTION
This PR fixes a couple of linux build issues.

1. `xlocale.h` was removed from `glibc` as noted [here](https://sourceware.org/glibc/wiki/Release/2.26#Removal_of_.27xlocale.h.27).
1. There appears to be a name conflict with `TRAP_BRANCH`, which is also defined in `signal.h` ([reference](http://man7.org/linux/man-pages/man2/sigaction.2.html)).