### PR TITLE
Fix town names on regional map

### DIFF
--- a/src/ui-map.c
+++ b/src/ui-map.c
@@ -1077,7 +1077,6 @@ void do_cmd_view_map(void)
 	/* Get dimensions for the regional map */
 	num_down = (hgt - 6) / 8;
 	num_across = (wid - 24) / 20;
-	num = (num_down < num_across ? num_down : num_across);
 
 	/* Hack - limit range for now */
 	num = 2;

--- a/src/ui-map.c
+++ b/src/ui-map.c
@@ -1071,11 +1071,6 @@ void do_cmd_view_map(void)
 	int num_down, num_across, num, centre_place, next_place;
 	ui_event ke;
 
-	//if (Term->view_map_hook) {
-	//	(*(Term->view_map_hook))(Term);
-	//	return;
-	//}
-
 	/* Get size */
 	Term_get_size(&wid, &hgt);
 

--- a/src/ui-map.c
+++ b/src/ui-map.c
@@ -938,7 +938,7 @@ static void regional_map(int num, int centre_place)
 			continue;
 
 		/* Get the place */
-		col = (i % side) * 10 + 1;
+		col = (i % side) * 18 + 1;
 		row = (i / side) * 4 + 1;
 
 		/* Get the level string */
@@ -996,7 +996,7 @@ static void regional_map(int num, int centre_place)
 		c_put_str(i == size / 2 ? COLOUR_WHITE : COLOUR_L_DARK, lev_name,
 				  row + 1, col);
 		if (world->levels[place[i]].east) {
-			c_put_str(COLOUR_WHITE, "-", row + 1, col + 8);
+			c_put_str(COLOUR_WHITE, "   ---", row + 1, col + 8);
 		}
 		if (world->levels[place[i]].down) {
 			lev = &world->levels[place[i]];


### PR DESCRIPTION
There was an issue on displaying long town names like "Taur-Im-Duinath". Town name just did not fit on map.
Here's possible solution:
![wide map](https://user-images.githubusercontent.com/53460983/130333076-4a86dcca-7f98-49b3-8d41-3207fa2dafbe.png)


P.S. Additional commits just to clean up the code, suggested by the static analyzer of CLion.