### PR TITLE
Fixed a bug of displaying the regional map in a hybrid dungeon.

### DIFF
--- a/src/ui-map.c
+++ b/src/ui-map.c
@@ -1072,8 +1072,8 @@ void do_cmd_view_map(void)
 	tile_width = w;
 	tile_height = h;
 
-	/* Regional map if not in the dungeon */
-	if (level_topography(player->place) != TOP_CAVE) {
+	/* Show regional map only if there is wilderness */
+	if (!streq(world->name, "Hybrid Dungeon") && !streq(world->name, "Angband Dungeon")) {
 		centre_place = player->place;
 		while (true) {
 			/* Get the adjacent levels */


### PR DESCRIPTION
Fixed a bug of displaying the regional map in a hybrid dungeon.
There was condition where we check if current topography is not `TOP_CAVE`.

Now I'm playing in hybrid dungeon mode. And when I reached Nan Dungortheb (which is `TOP_VALLEY`) the bug occurs.

I propose to expand the condition and check the name of the world to show regional map only if wilderness is supposed to be.