### PR TITLE
Changed mention of "nowhere" when choosing the recall point

### DIFF
--- a/src/ui-recall.c
+++ b/src/ui-recall.c
@@ -63,7 +63,7 @@ static void recall_display(struct menu *menu, int oid, bool cursor, int row,
 			my_strcpy(place, format("%s Town   ", locality_name(region)),
 					  sizeof(place));
 		} else {
-			my_strcpy(place, "Nowhere     ", sizeof(place));
+		    my_strcpy(place, "No location set     ", sizeof(place));
 		}
 	} else {
 		my_strcpy(place, "Don't replace     ", sizeof(place));


### PR DESCRIPTION
I am always confused a little when the "nowhere" option appears after reading a scroll ?Word of Recall.

I can suggest to call this option `Home` keeping the same effect.
Or maybe there is something behind this that I don't understand..