### PR TITLE
Expanded condition for displaying a regional map

### DIFF
--- a/src/ui-map.c
+++ b/src/ui-map.c
@@ -36,6 +36,8 @@
 #include "ui-term.h"
 
 
+bool showRegionalMap();
+
 /**
  * Hack -- Hallucinatory monster
  */
@@ -1072,8 +1074,8 @@ void do_cmd_view_map(void)
 	tile_width = w;
 	tile_height = h;
 
-	/* Show regional map only if there is wilderness */
-	if (!streq(world->name, "Hybrid Dungeon") && !streq(world->name, "Angband Dungeon")) {
+	/* Show regional map only if there is wilderness and player not in the dungeon */
+	if (showRegionalMap()) {
 		centre_place = player->place;
 		while (true) {
 			/* Get the adjacent levels */
@@ -1130,6 +1132,11 @@ void do_cmd_view_map(void)
 
 	/* Load screen */
 	screen_load();
+}
+
+bool showRegionalMap(void) {
+    return (!streq(world->name, "Hybrid Dungeon") && !streq(world->name, "Angband Dungeon")) &&
+        level_topography(player->place) != TOP_CAVE;
 }
 
 

--- a/src/ui-map.h
+++ b/src/ui-map.h
@@ -23,3 +23,4 @@ extern void print_rel(wchar_t c, byte a, int y, int x);
 extern void prt_map(void);
 extern void display_map(int *cy, int *cx);
 extern void do_cmd_view_map(void);
+bool showRegionalMap(void);


### PR DESCRIPTION
Just started a new character in standard wilderness mode. And I noticed that the regional map is shown while I'm in the dungeon. Perhaps this is a feature, not the bug, huh?

What do you think, should the player be able to get information about the locations surrounding the dungeon? 