### PR TITLE
Add LOS flag to the Travelling Merchant so it behaves the same as it …

### DIFF
--- a/lib/gamedata/terrain.txt
+++ b/lib/gamedata/terrain.txt
@@ -229,7 +229,7 @@ desc: apart from on your person.
 name:Travelling Merchant
 graphics:9:u
 priority:20
-flags:SHOP | PROJECT | PASSABLE | PERMANENT | INTERESTING | EASY
+flags:SHOP | LOS | PROJECT | PASSABLE | PERMANENT | INTERESTING | EASY
 info:9:0
 look-prefix:the entrance to the
 look-in-preposition:at


### PR DESCRIPTION
…did before the change from square_iswall() to square_allowslos().  Related to https://github.com/angband/angband/pull/5100 .  May resolve https://github.com/NickMcConnell/FAangband/issues/336 .