### PR TITLE
Don't allow terrain that generates falls to be a teleport destination.

### DIFF
--- a/src/effect-handler-general.c
+++ b/src/effect-handler-general.c
@@ -149,6 +149,7 @@ static bool has_teleport_destination_prereqs(struct chunk *c, struct loc grid,
 	}
 	if (square(c, grid)->mon
 			|| square_isdamaging(c, grid)
+			|| square_isfall(c, grid)
 			|| square_iswebbed(c, grid)
 			|| square_isshop(c, grid)) {
 		return false;


### PR DESCRIPTION
Passable watery terrain is allowed (after https://github.com/NickMcConnell/FAangband/commit/a346896d9290d87a13137467afbda4ca10006f78 ) which may be problematic - teleport other on a fiery monster could strand it in a body of water.