### PR TITLE
In object design, properly calculate change in cost for altering …

### DIFF
--- a/src/obj-design.c
+++ b/src/obj-design.c
@@ -220,9 +220,6 @@ static bool get_property(struct artifact *art, struct object *obj,
 	struct obj_property *prop = lookup_obj_property_name(prop_name);
 	assert(prop);
 
-	/* Basic cost */
-	cost = property_cost(prop, value, false);
-
 	assert(art || ((art == NULL) && obj));
 	switch (prop->type) {
 		case OBJ_PROPERTY_STAT:
@@ -231,6 +228,8 @@ static bool get_property(struct artifact *art, struct object *obj,
 			int16_t *modifiers = art ? art->modifiers : obj->modifiers;
 			int cur_value = modifiers[prop->index];
 			int cur_cost = art ? 0 : property_cost(prop, cur_value, false);
+
+			cost = property_cost(prop, cur_value + value, false);
 			if (take_money(cost - cur_cost, on_credit)) {
 				modifiers[prop->index] += value;
 				return true;
@@ -240,6 +239,8 @@ static bool get_property(struct artifact *art, struct object *obj,
 		case OBJ_PROPERTY_FLAG:
 		{
 			bitflag *flags = art ? art->flags : obj->flags;
+
+			cost = property_cost(prop, value, false);
 			if (take_money(cost, on_credit)) {
 				of_on(flags, prop->index);
 				return true;
@@ -251,6 +252,8 @@ static bool get_property(struct artifact *art, struct object *obj,
 			struct element_info *el_info = art ? art->el_info : obj->el_info;
 			int cur_value = RES_LEVEL_BASE - el_info[prop->index].res_level;
 			int cur_cost = art ? 0 : property_cost(prop, cur_value, false);
+
+			cost = property_cost(prop, cur_value - value, false);
 			if (take_money(cost - cur_cost, on_credit)) {
 				el_info[prop->index].res_level -= value;
 				return true;
@@ -260,6 +263,8 @@ static bool get_property(struct artifact *art, struct object *obj,
 		case OBJ_PROPERTY_IGNORE:
 		{
 			struct element_info *el_info = art ? art->el_info : obj->el_info;
+
+			cost = property_cost(prop, value, false);
 			if (take_money(cost, on_credit)) {
 				el_info[prop->index].flags |= EL_INFO_IGNORE;
 				return true;
@@ -276,6 +281,8 @@ static bool get_property(struct artifact *art, struct object *obj,
 					break;
 			}
 			assert(pick < z_info->brand_max);
+
+			cost = property_cost(prop, value, false);
 
 			/* Simple for artifacts */
 			if (art) {
@@ -315,6 +322,8 @@ static bool get_property(struct artifact *art, struct object *obj,
 					break;
 			}
 			assert(pick < z_info->slay_max);
+
+			cost = property_cost(prop, value, false);
 
 			/* Simple for artifacts */
 			if (art) {
@@ -427,6 +436,8 @@ static bool get_property(struct artifact *art, struct object *obj,
 				}
 				cur_value = *bonus;
 				cur_cost = art ? 0 : property_cost(prop, cur_value, false);
+				cost = property_cost(prop,
+					value + cur_value, false);
 				if (take_money(cost - cur_cost, on_credit)) {
 					*bonus += value;
 					return true;


### PR DESCRIPTION
…statistic, modifier, resistance, or combat value when the initial value is not zero (RES_LEVEL_BASE for a resistance).  Resolves https://github.com/NickMcConnell/FAangband/issues/360 .

Using the debugging command to get object statistics (augmented to count the number of non-artifact rings and amulets with given values for the statistics, modifiers, resistances, and combat values) got this result for before and after the change.  Both used 20000 clearing runs.  The one before the change got 152673 pieces of non-artifact jewelry in those runs.  The one after the change got 153694 pieces of non-artifact jewelry.

Speed modifier    # of pieces before change     # of pieces after change
-30 or less           37                                             37
-29                        0                                               0
-28                        0                                               0
-27                        0                                               0
-26                        0                                               0
-25                        11                                              18
-24                        0                                               0
-23                        0                                               0
-22                        0                                               0
-21                         0                                               0
-20                        12                                              9
-19                        0                                                0
-18                        0                                                0
-17                        0                                                0
-16                        0                                                0
-15                        0                                                0
-14                        0                                                0
-13                        0                                                0
-12                        0                                                0
-11                         0                                                0
-10                        0                                                0
-9                          0                                                0
-8                          22                                              22
-7                          15                                               24
-6                          27                                              24
-5                          31                                              34
-4                          25                                              23
-3                          0                                                0
-2                          0                                                0
-1                           0                                                0
0                            135996                                     132690
1                             5581                                          6921
2                            5960                                          7895
3                            2746                                          3492
4                            1001                                           1223
5                            182                                             279
6                            238                                            277
7                            322                                            307
8                            213                                            214
9                            114                                             100
10                           62                                              49
11                            28                                             36
12                           18                                              9
13                           9                                               4
14                           7                                               4
15                           0                                               2
16                           1                                                1
17                           0                                               0
18                           0                                               0
19                           2                                               0
20                           2                                              0
21                           0                                              0
22                           0                                              0
23                           1                                              0
24                           0                                              0
25                           1                                              0
26                           0                                             0
27                           0                                             0
28                           0                                             0
29                           1                                              0
30 or more            8                                              0