### PR TITLE
Change return type of effect_value_base_trap_power() to match …

### DIFF
--- a/src/effects.c
+++ b/src/effects.c
@@ -360,7 +360,7 @@ static int32_t effect_value_base_monster_percent_hp_gone(void)
 	return mon ? (((mon->maxhp - mon->hp) * 100) / mon->maxhp) : 0;
 }
 
-static int effect_value_base_trap_power(void)
+static int32_t effect_value_base_trap_power(void)
 {
 	int plev = player->lev;
 	int n = plev + (plev * plev) / 25;


### PR DESCRIPTION
…expression_base_value_f typedef.  Gets rid of warning when compiling for the Nintendo 3ds.