### PR TITLE
Avoid "logical 'and' of mutually exclusive tests is always false" …

### DIFF
--- a/src/obj-make.c
+++ b/src/obj-make.c
@@ -507,7 +507,7 @@ static void apply_resistances(struct object *obj, int lev)
 		res = RES_LEVEL_BASE - obj->el_info[i].res_level;
 
 		/* Only randomise proper resistances */
-		if ((res > RES_LEVEL_MIN) && (res < RES_LEVEL_BASE)) {
+		if ((res > 0) && (res < RES_LEVEL_BASE - RES_LEVEL_MAX)) {
 			if (randint0(2) == 0) {
 				obj->el_info[i].res_level -= randint0(res >> 2);
 			} else {


### PR DESCRIPTION
…warning from gcc.  Should restore the 1.4.5 behavior of randomising resistances applied to an item.