### PR TITLE
Tweak equippable comparison display

### DIFF
--- a/lib/gamedata/ui_entry.txt
+++ b/lib/gamedata/ui_entry.txt
@@ -257,6 +257,7 @@ priority:-12
 name:bless_ui_compact_0
 template:good_flag_ui_compact_0
 label:Bless
+label2:Bs
 priority:-13
 
 # The following use other_flag_ui_compact_0 from ui_entry_base.txt.
@@ -318,7 +319,7 @@ label:Fragile
 label5:Fragl
 priority:-7
 
-# The following use numeric_as_sign_ui_0 from ui_entry_base.txt.
+# The following use numeric_modifier_ui_0 from ui_entry_base.txt.
 
 name:stealth_ui_compact_0
 template:numeric_modifier_ui_0
@@ -391,4 +392,4 @@ template:numeric_modifier_ui_0
 label:Magic Mastery
 label5:MMast
 label2:MM
-priority:-10
+priority:-11

--- a/lib/gamedata/ui_entry_base.txt
+++ b/lib/gamedata/ui_entry_base.txt
@@ -42,6 +42,7 @@ name:numeric_modifier_ui_0
 renderer:char_screen1_numeric_renderer
 combine:ADD
 category:CHAR_SCREEN1
+category:EQUIPCMP_SCREEN
 category:modifiers
 flags:TIMED_AS_AUX
 desc:Template for one of the modifiers shown on the second character screen.


### PR DESCRIPTION
Include the numeric modifiers (third column from the second page of the character sheet), disambiguate the two character abbreviations for blessed melee and attack speed, give magic mastery a lower priority than movement speed, and correct a comment.  Resolves part of https://github.com/NickMcConnell/FAangband/issues/372 .