### PR TITLE
Avoid explicit TMD_OPP_* references

### DIFF
--- a/src/player-calcs.c
+++ b/src/player-calcs.c
@@ -2525,20 +2525,9 @@ void calc_bonuses(struct player *p, struct player_state *state, bool known_only,
 	if (p->timed[TMD_TERROR]) {
 		state->speed += 10;
 	}
-	if (p->timed[TMD_OPP_ACID]) {
-		apply_resist(&state->el_info[ELEM_ACID].res_level, RES_BOOST_NORMAL);
-	}
-	if (p->timed[TMD_OPP_ELEC]) {
-		apply_resist(&state->el_info[ELEM_ELEC].res_level, RES_BOOST_NORMAL);
-	}
-	if (p->timed[TMD_OPP_FIRE]) {
-		apply_resist(&state->el_info[ELEM_FIRE].res_level, RES_BOOST_NORMAL);
-	}
-	if (p->timed[TMD_OPP_COLD]) {
-		apply_resist(&state->el_info[ELEM_COLD].res_level, RES_BOOST_NORMAL);
-	}
-	if (p->timed[TMD_OPP_POIS]) {
-		apply_resist(&state->el_info[ELEM_POIS].res_level, RES_BOOST_NORMAL);
+	for (i = 0; i < TMD_MAX; ++i) {
+		if (!p->timed[i] || timed_effects[i].temp_resist == -1) continue;
+		apply_resist(&state->el_info[timed_effects[i].temp_resist].res_level, RES_BOOST_NORMAL);
 	}
 	if (p->timed[TMD_CONFUSED]) {
 		adjust_skill_scale(&state->skills[SKILL_DEVICE], -1, 4, 0);


### PR DESCRIPTION
That's in the spirit of Angband's https://github.com/angband/angband/commit/2afd564a8f1eae648da797ae85826f39299ec3e9 : only require changes to list-player-timed.h and player_timed.txt to add a new temporary resistance for an existing element.  Of course, would still need to change objects, artifacts, activations, or spells to use the new temporary resistance.