### PR TITLE
Correct SHERO activation description merged from Angband

### DIFF
--- a/lib/gamedata/activation.txt
+++ b/lib/gamedata/activation.txt
@@ -351,7 +351,7 @@ effect:CURE:AFRAID
 effect:TIMED_INC:SHERO
 dice:25+1d25
 desc:restores 30 hit points, removes fear and grants you resistance to fear,
-desc: +25 to-hit, and -10AC for 1d25+25 turns
+desc: +24 to-hit for melee, and -10AC for 1d25+25 turns
 
 name:BERSERKER
 aim:0


### PR DESCRIPTION
In FAAngband, it is +24 to-hit (see player-calcs.c:2512) and not +25 as in Angband.  For both, the to-hit bonus only applies for melee.