### PR TITLE
Keep player's depth consistent when thrall option is toggled

### DIFF
--- a/src/ui-options.c
+++ b/src/ui-options.c
@@ -380,6 +380,8 @@ static void option_toggle_menu(const char *name, int page)
 void do_cmd_options_birth(void)
 {
 	option_toggle_menu("Birth options", OPT_PAGE_BIRTH + 10);
+	/* Keep player's depth consistent with the thrall setting. */
+	player->depth = OPT(player, birth_thrall) ? 58 : 0;
 }
 
 


### PR DESCRIPTION
Resolves Sideways' report here, https://angband.live/forums/forum/angband/variants/248837-faangband-nightly-crashes-on-game-resumption?p=248839#post248839 , of town monsters in Anfauglith 58.