### PR TITLE
Fix logic for blow with non-NULL blow_effect2

### DIFF
--- a/src/mon-make.c
+++ b/src/mon-make.c
@@ -639,7 +639,7 @@ static void process_ghost_race_class(struct player_race *p_race,
 					if (!race->blow[i].effect) break;
 					if (strcmp(race->blow[i].effect->name, "HURT") == 0) {
 						race->blow[i].effect =
-							lookup_monster_blow_effect(lev->blow_effect1);
+							lookup_monster_blow_effect(lev->blow_effect2);
 						hurt++;
 						break;
 					}


### PR DESCRIPTION
Resolves crash seen placing a ghost with a blow that had NULL for blow_effect1 and not NULL for blow_effect2.