### PR TITLE
Deeply copy blows for player ghost

### DIFF
--- a/src/mon-init.c
+++ b/src/mon-init.c
@@ -1906,6 +1906,12 @@ static void cleanup_monster(void)
 		mem_free(r->blow);
 	}
 
+	/*
+	 * Melee blows for the ghost race have to be freed.  The rest of it
+	 * is a shallow copy of one of the other races.
+	 */
+	mem_free(r_info[z_info->r_max - 1].blow);
+
 	mem_free(r_info);
 }
 


### PR DESCRIPTION
Avoids modifying blows of the base race when creating a ghost.  Without that change, generating thousands of levels using the debugging disconnection statistics command at Angband 65 triggered the undefined behavior sanitizer when the number of dice sides for a melee blow overflowed.