### PR TITLE
Change how chunk_copy() skips ghost not used from the source chunk

### DIFF
--- a/src/mon-make.c
+++ b/src/mon-make.c
@@ -995,10 +995,10 @@ void delete_monster_idx(struct chunk *c, int m_idx)
 		if (player->upkeep->monster_race == mon->race) {
 			player->upkeep->monster_race = NULL;
 		}
-		cave->ghost->bones_selector = 0;
-		cave->ghost->has_spoken = false;
-		cave->ghost->string_type = 0;
-		my_strcpy(cave->ghost->string, "", sizeof(cave->ghost->string));
+		c->ghost->bones_selector = 0;
+		c->ghost->has_spoken = false;
+		c->ghost->string_type = 0;
+		my_strcpy(c->ghost->string, "", sizeof(c->ghost->string));
 	}
 
 	/* Wipe the Monster */


### PR DESCRIPTION
Also use passed chunk argument rather than cave when resetting the ghost in delete_monster_idx().

Avoids an assertion failure copying over the monster groups when both chunks have a ghost.

This is cleaner than https://github.com/NickMcConnell/FAangband/pull/423 and possible now that delete_monster_idx() takes a chunk argument.