### PR TITLE
Protect against overflow when adding a ghost to the monster rating

### DIFF
--- a/src/gen-chunk.c
+++ b/src/gen-chunk.c
@@ -540,6 +540,15 @@ bool chunk_copy(struct chunk *dest, struct player *p, struct chunk *source,
 
 		delete_monster_idx(dest, skipped_ghost_id);
 		*dest->ghost = preserved_ghost;
+		/*
+		 * Compensate for the change to monster rating, but do
+		 * nothing if it saturated:  do not know what to subtract
+		 * in that case.
+		 */
+		if (dest->mon_rating != UINT32_MAX) {
+			assert(dest->mon_rating >= 10);
+			dest->mon_rating -= 10;
+		}
 	}
 
 	return true;

--- a/src/mon-make.c
+++ b/src/mon-make.c
@@ -879,7 +879,7 @@ bool prepare_ghost(struct chunk *c, int r_idx, struct monster *mon,
 	}
 
 	/* Increase the level feeling */
-	c->mon_rating += 10;
+	add_to_monster_rating(c, 10);
 
 	/* Player ghosts are "seen" whenever generated. */
 	lore->sights = 1;


### PR DESCRIPTION
Also adjust, when possible, the monster rating for skipping a ghost in chunk_copy().