### PR TITLE
Replace calls to strcpy() with my_strcpy()

### DIFF
--- a/src/datafile.c
+++ b/src/datafile.c
@@ -682,7 +682,7 @@ void deactivate_randart_file(void)
 /**
  * Taken from Zangband.  What a good idea!
  */
-errr get_rnd_line(const char *file_name, char *output)
+errr get_rnd_line(const char *file_name, char *output, size_t outsz)
 {
 	ang_file *fp;
 	char buf[1024];
@@ -714,7 +714,7 @@ errr get_rnd_line(const char *file_name, char *output)
 			break;
 	}
 
-	strcpy(output, buf);
+	my_strcpy(output, buf, outsz);
 
 	/* Close the file */
 	file_close(fp);

--- a/src/datafile.h
+++ b/src/datafile.h
@@ -62,6 +62,6 @@ void file_archive(const char *fname, const char *append);
 bool randart_file_exists(void);
 void activate_randart_file(void);
 void deactivate_randart_file(void);
-errr get_rnd_line(const char *file_name, char *output);
+errr get_rnd_line(const char *file_name, char *output, size_t outsz);
 
 #endif /* !DATAFILE_H */

--- a/src/mon-move.c
+++ b/src/mon-move.c
@@ -1731,10 +1731,10 @@ static void monster_turn(struct monster *mon)
 		if (monster_is_visible(mon)) {
 			monster_desc(m_name, sizeof(m_name), mon, MDESC_CAPITAL);
 		} else {
-			strcpy(m_name, "It");
+			my_strcpy(m_name, "It", sizeof(m_name));
 		}
 
-		if (!get_rnd_line("bravado.txt", bravado)) {
+		if (!get_rnd_line("bravado.txt", bravado, sizeof(bravado))) {
 			msg("%s %s", m_name, bravado);
 		}
 	} else if (rf_has(mon->race->flags, RF_PLAYER_GHOST)) {

--- a/src/obj-design.c
+++ b/src/obj-design.c
@@ -3824,15 +3824,15 @@ static void find_word(struct artifact *art, char *word, size_t len)
 	art_name[0] = '\0';
 	if (art->cost == 0L) {
 		if (tval_is_weapon_a(art)) {
-			get_rnd_line("w_cursed.txt", art_name);
+			get_rnd_line("w_cursed.txt", art_name, sizeof(art_name));
 		} else {
-			get_rnd_line("a_cursed.txt", art_name);
+			get_rnd_line("a_cursed.txt", art_name, sizeof(art_name));
 		}
 	} else {
 		if (tval_is_weapon_a(art)) {
-			get_rnd_line("w_normal.txt", art_name);
+			get_rnd_line("w_normal.txt", art_name, sizeof(art_name));
 		} else {
-			get_rnd_line("a_normal.txt", art_name);
+			get_rnd_line("a_normal.txt", art_name, sizeof(art_name));
 		}
 	}
 


### PR DESCRIPTION
Avoids warnings on OpenBSD.