### PR TITLE
docs - remove stray parenthesis from conf.py

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -21,7 +21,6 @@ import os
 project = "FAangband"
 copyright = "2025, Angband developers past and present"
 author = "Angband developers past and present"
-)
 
 # The full version, including alpha/beta/rc tags
 # There's extra clutter here (and for the HTML theme) to allow conf.py to


### PR DESCRIPTION
That's a regression introduced by b71d5a96564f9cbe44ab42d7cd379ad4e9272537 .