### PR TITLE
Prevent quest monsters from appearing where they should not

### DIFF
--- a/lib/gamedata/quest.txt
+++ b/lib/gamedata/quest.txt
@@ -89,6 +89,5 @@ map:Extended Wilderness
 place:TOL_IN_GAURHOTH:85
 map:Hybrid Dungeon
 place:TOL_IN_GAURHOTH:85
-#Make Sauron not a quest while he can apparently appear earlier
-#map:Angband Dungeon
-#place:ANGBAND:99:block
+map:Angband Dungeon
+place:ANGBAND:99:block

--- a/src/mon-make.c
+++ b/src/mon-make.c
@@ -225,6 +225,11 @@ static bool get_mon_forbidden(struct monster_race *race)
 		return true;
 	}
 
+	/* Forbid a unique quest monster if this is not its quest level */
+	if (quest_misplaced_unique_monster_check(race, player)) {
+		return true;
+	}
+
 	return false;
 }
 

--- a/src/player-quest.c
+++ b/src/player-quest.c
@@ -441,6 +441,35 @@ bool quest_unique_monster_check(const struct monster_race *race)
 }
 
 /**
+ * Check if a monster is a unique quest monster and the player is not in
+ * the place where that monster appears.
+ */
+bool quest_misplaced_unique_monster_check(const struct monster_race *race,
+		struct player *p)
+{
+	const struct quest *quest = quests;
+
+	while (quest) {
+		if (((quest->type == QUEST_UNIQUE)
+				|| (quest->type == QUEST_FINAL))
+				&& (quest->race == race)) {
+			const struct quest_place *q_place = quest->place;
+
+			while (q_place) {
+				if (q_place->map == world) {
+					return (q_place->place == p->place) ?
+						false : true;
+				}
+				q_place = q_place->next;
+			}
+			return false;
+		}
+		quest = quest->next;
+	}
+	return false;
+}
+
+/**
  * Check if this (now dead) monster is a quest monster, and act appropriately
  */
 bool quest_monster_death_check(struct player *p, const struct monster *mon)

--- a/src/player-quest.h
+++ b/src/player-quest.h
@@ -28,6 +28,8 @@ int quests_count(void);
 struct quest *find_quest(int place);
 bool quest_forbid_downstairs(int place);
 bool quest_unique_monster_check(const struct monster_race *race);
+bool quest_misplaced_unique_monster_check(const struct monster_race *race,
+		struct player *p);
 bool quest_monster_death_check(struct player *p, const struct monster *mon);
 bool quest_place_check(struct player *p);
 extern struct file_parser quests_parser;


### PR DESCRIPTION
Resolves https://github.com/NickMcConnell/FAangband/issues/434 .  With the current quests, only Sauron, when playing Angband dungeon mode, could appear where he should not (he has the FORCE_DEPTH and GAUROTH flags; the latter is ignored in Angband dungeon mode; the former means he could appear in Angband dungeon mode anywhere deeper than Angband 84 before this change).