### PR TITLE
Fold applying ego activation into ego_apply_magic()

### DIFF
--- a/src/obj-make.c
+++ b/src/obj-make.c
@@ -697,6 +697,11 @@ void ego_apply_magic(struct object *obj, int level, aspect rand_aspect)
 	/* Apply special resistances and randomise */
 	apply_resistances(obj, level);
 
+	/* Activation */
+	if (obj->ego->activation) {
+		obj->activation = obj->ego->activation;
+	}
+
 	return;
 }
 
@@ -752,11 +757,6 @@ static void make_ego_item(struct object *obj, int level)
 	/* Actually apply the ego template to the item */
 	if (obj->ego) {
 		ego_apply_magic(obj, level, RANDOMISE);
-
-		/* Activation */
-		if (obj->ego->activation) {
-			obj->activation = obj->ego->activation;
-		}
 	}
 
 	return;


### PR DESCRIPTION
That way, other paths which might create ego items (the debugging commands, birth items, the BRAND_WEAPON effect) also get the activation.  Also affects the generated dummy item for the ego knowledge menu, but, since the activation information is not displayed when OINFO_EGO is used, the player will not see a difference there.