### PR TITLE
Actually remove contradictory activations

### DIFF
--- a/src/obj-design.c
+++ b/src/obj-design.c
@@ -3769,7 +3769,11 @@ static void remove_contradictory_activation(struct artifact *art,
 	}
 
 	if (redundant) {
-		act = NULL;
+		if (art) {
+			art->activation = NULL;
+		} else {
+			obj->activation = NULL;
+		}
 	}
 }
 


### PR DESCRIPTION
In testing, did not encounter contradictory activations for about 15 new players (so in the randarts or designed jewelry for a store's initial stock).  So, remove_contradictory_activation() does not appear to have much effect currently, even with this correction.