### PR TITLE
Avoid mismatched format warning

### DIFF
--- a/src/obj-design.c
+++ b/src/obj-design.c
@@ -3959,7 +3959,14 @@ static void write_randart_file_entry(ang_file *fff, const struct artifact *art)
 	/* Output graphics if necessary */
 	if (kind->kidx >= z_info->ordinary_kind_max) {
 		const char *attr = attr_to_text(kind->d_attr);
-		file_putf(fff, "graphics:%c:%s\n", kind->d_char, attr);
+		char *d_char = mem_alloc(text_wcsz() + 1);
+		int nbyte = text_wctomb(d_char, kind->d_char);
+
+		if (nbyte > 0) {
+			d_char[nbyte] = '\0';
+			file_putf(fff, "graphics:%s:%s\n", d_char, attr);
+		}
+		mem_free(d_char);
 	}
 
 	/* Output level, weight and cost */


### PR DESCRIPTION
Seen with gcc 12.2.0 on a 32-bit version of Debian 12.